### PR TITLE
fix: Correct SQL column references in migration report generation

### DIFF
--- a/McpChatWeb/Program.cs
+++ b/McpChatWeb/Program.cs
@@ -899,9 +899,9 @@ app.MapGet("/api/runs/{runId}/report", async (int runId) =>
 		var summaryCmd = connection.CreateCommand();
 		summaryCmd.CommandText = @"
 			SELECT 
-				COUNT(DISTINCT source_file) as total_files,
-				COUNT(DISTINCT CASE WHEN source_file LIKE '%.cbl' THEN source_file END) as cobol_programs,
-				COUNT(DISTINCT CASE WHEN source_file LIKE '%.cpy' THEN source_file END) as copybooks
+				COUNT(DISTINCT file_name) as total_files,
+				COUNT(DISTINCT CASE WHEN file_name LIKE '%.cbl' THEN file_name END) as cobol_programs,
+				COUNT(DISTINCT CASE WHEN file_name LIKE '%.cpy' THEN file_name END) as copybooks
 			FROM cobol_files 
 			WHERE run_id = @runId";
 		summaryCmd.Parameters.AddWithValue("@runId", runId);
@@ -966,7 +966,8 @@ app.MapGet("/api/runs/{runId}/report", async (int runId) =>
 
 		var filesCmd = connection.CreateCommand();
 		filesCmd.CommandText = @"
-			SELECT file_name, file_path, line_count
+			SELECT file_name, file_path, 
+			       LENGTH(content) - LENGTH(REPLACE(content, char(10), '')) + 1 as line_count
 			FROM cobol_files 
 			WHERE run_id = @runId
 			ORDER BY file_name";


### PR DESCRIPTION
Fixes #8 

- Fixed SQL queries using non-existent 'source_file' column from cobol_files table
- Changed to use correct 'file_name' column for file inventory queries
- Calculate line_count dynamically from content field using LENGTH formula
- Matches database schema: cobol_files(id, run_id, file_name, file_path, is_copybook, content)
- Aligns with pattern used in HybridMigrationRepository.cs

Fixes parse errors when generating comprehensive migration report:
  - 'Total COBOL Files' query
  - 'Programs (.cbl)' query
  - 'Copybooks (.cpy)' query
  - File inventory table output with line counts