### PR TITLE
fix: use ArgumentList to prevent command injection in ProcessManager

### DIFF
--- a/McpChatWeb/Services/ProcessManager.cs
+++ b/McpChatWeb/Services/ProcessManager.cs
@@ -118,13 +118,17 @@ public class ProcessManager : IDisposable
         var psi = new ProcessStartInfo
         {
             FileName = executable,
-            Arguments = arguments,
             WorkingDirectory = _repoRoot,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,
             CreateNoWindow = true
         };
+
+        foreach (var argument in arguments)
+        {
+            psi.ArgumentList.Add(argument);
+        }
 
         // Set environment variables
         psi.Environment["TARGET_LANGUAGE"] = targetLanguage;
@@ -243,7 +247,7 @@ public class ProcessManager : IDisposable
             // Monitor completion
             _ = MonitorProcessAsync(run);
 
-            run.AppendLog($"[PORTAL] Started: {executable} {arguments}");
+            run.AppendLog($"[PORTAL] Started: {executable} {string.Join(" ", arguments)}");
             run.AppendLog($"[PORTAL] PID: {process.Id} | Target: {targetLanguage} | Speed: {speedProfile}");
 
             Console.WriteLine($"🚀 Run '{run.Name}' started (PID: {process.Id}, command: {command})");
@@ -293,8 +297,17 @@ public class ProcessManager : IDisposable
 
         try
         {
-            // Send SIGSTOP (19) on Unix
-            var killProc = Process.Start("kill", $"-STOP {run.Process.Id}");
+            // Send SIGSTOP on Unix via ArgumentList to avoid shell injection
+            var killPsi = new ProcessStartInfo
+            {
+                FileName = "kill",
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            killPsi.ArgumentList.Add("-STOP");
+            killPsi.ArgumentList.Add(run.Process.Id.ToString());
+
+            var killProc = Process.Start(killPsi);
             killProc?.WaitForExit(3000);
             run.Status = "paused";
             run.AppendLog("[PORTAL] Process paused by user");
@@ -319,7 +332,17 @@ public class ProcessManager : IDisposable
 
         try
         {
-            var killProc = Process.Start("kill", $"-CONT {run.Process.Id}");
+            // Send SIGCONT on Unix via ArgumentList to avoid shell injection
+            var killPsi = new ProcessStartInfo
+            {
+                FileName = "kill",
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            killPsi.ArgumentList.Add("-CONT");
+            killPsi.ArgumentList.Add(run.Process.Id.ToString());
+
+            var killProc = Process.Start(killPsi);
             killProc?.WaitForExit(3000);
             run.Status = "running";
             run.AppendLog("[PORTAL] Process resumed by user");
@@ -349,28 +372,28 @@ public class ProcessManager : IDisposable
         return _runs.TryGetValue(runId, out var run) ? run : null;
     }
 
-    private (string executable, string arguments) BuildCommand(
+    private (string executable, string[] arguments) BuildCommand(
         string command, string targetLang, string speedProfile, string? sourceFolder)
     {
         var dotnet = "dotnet";
-        var source = sourceFolder ?? "source";
+        var source = $"./{sourceFolder ?? "source"}";
         var project = Path.Combine(_repoRoot, "CobolToQuarkusMigration.csproj");
 
         return command.ToLowerInvariant() switch
         {
             "migrate" or "run" or "full" =>
-                (dotnet, $"run --project \"{project}\" -- --source ./{source}"),
+                (dotnet, new[] { "run", "--project", project, "--", "--source", source }),
 
             "reverse-engineer" or "reverse" or "re" =>
-                (dotnet, $"run --project \"{project}\" -- reverse-engineer --source ./{source} --output output"),
+                (dotnet, new[] { "run", "--project", project, "--", "reverse-engineer", "--source", source, "--output", "output" }),
 
             "convert-only" or "convert" =>
-                (dotnet, $"run --project \"{project}\" -- --source ./{source} --skip-reverse-engineering"),
+                (dotnet, new[] { "run", "--project", project, "--", "--source", source, "--skip-reverse-engineering" }),
 
             "resume" =>
-                (dotnet, $"run --project \"{project}\" -- --source ./{source} --resume"),
+                (dotnet, new[] { "run", "--project", project, "--", "--source", source, "--resume" }),
 
-            _ => (dotnet, $"run --project \"{project}\" -- --source ./{source}")
+            _ => (dotnet, new[] { "run", "--project", project, "--", "--source", source })
         };
     }
 


### PR DESCRIPTION
## Security Fix

Resolves [code-scanning alert #6](https://github.com/Azure-Samples/Legacy-Modernization-Agents/security/code-scanning/6) — **Uncontrolled command line** in `ProcessManager.cs`.

### Problem
`ProcessStartInfo.Arguments` accepts a single string that undergoes shell parsing, allowing potential command injection via user-controlled inputs (e.g. `sourceFolder`).

### Fix
- `BuildCommand` now returns `string[]` instead of an interpolated string
- `StartRun` populates `psi.ArgumentList` (discrete tokens, no shell interpretation)
- `PauseRun`/`ResumeRun` signal calls also converted to use `ArgumentList`

### Verification
- No build errors from `ProcessManager.cs` (pre-existing `CopilotChatClient.cs` error on main is unrelated)