### PR TITLE
fix: sanitize user-controlled paths in Program.cs to prevent path injection

### DIFF
--- a/McpChatWeb/Program.cs
+++ b/McpChatWeb/Program.cs
@@ -5627,7 +5627,7 @@ app.MapPost("/api/prompts/score/{promptId}", async (string promptId) =>
 		var promptFile = Path.GetFullPath(Path.Combine(repoRoot, "Agents", "Prompts", $"{sanitizedId}.md"));
 		var promptsDir = Path.GetFullPath(Path.Combine(repoRoot, "Agents", "Prompts"));
 
-		if (!promptFile.StartsWith(promptsDir + Path.DirectorySeparatorChar))
+		if (!promptFile.StartsWith(promptsDir + Path.DirectorySeparatorChar, StringComparison.Ordinal))
 			return Results.BadRequest(new { error = "Invalid prompt ID" });
 
 		if (!File.Exists(promptFile))
@@ -6314,7 +6314,8 @@ app.MapDelete("/api/source/files/{fileName}", (string fileName) =>
 		var targetPath = Path.GetFullPath(Path.Combine(repoRoot, "source", sanitized));
 		var sourceDir = Path.GetFullPath(Path.Combine(repoRoot, "source"));
 
-		if (!targetPath.StartsWith(sourceDir + Path.DirectorySeparatorChar) && targetPath != sourceDir)
+		if (!targetPath.StartsWith(sourceDir + Path.DirectorySeparatorChar, StringComparison.Ordinal)
+			&& targetPath != sourceDir)
 			return Results.BadRequest("Invalid path");
 
 		if (!File.Exists(targetPath))

--- a/McpChatWeb/Program.cs
+++ b/McpChatWeb/Program.cs
@@ -5623,9 +5623,15 @@ app.MapPost("/api/prompts/score/{promptId}", async (string promptId) =>
 				repoRoot = Path.GetFullPath("..");
 		}
 
-		var promptFile = Path.Combine(repoRoot, "Agents", "Prompts", $"{promptId}.md");
+		var sanitizedId = Path.GetFileName(promptId);
+		var promptFile = Path.GetFullPath(Path.Combine(repoRoot, "Agents", "Prompts", $"{sanitizedId}.md"));
+		var promptsDir = Path.GetFullPath(Path.Combine(repoRoot, "Agents", "Prompts"));
+
+		if (!promptFile.StartsWith(promptsDir + Path.DirectorySeparatorChar))
+			return Results.BadRequest(new { error = "Invalid prompt ID" });
+
 		if (!File.Exists(promptFile))
-			return Results.NotFound(new { error = $"Prompt '{promptId}' not found" });
+			return Results.NotFound(new { error = $"Prompt '{sanitizedId}' not found" });
 
 		// Read prompt content
 		var content = File.ReadAllText(promptFile);
@@ -6308,7 +6314,7 @@ app.MapDelete("/api/source/files/{fileName}", (string fileName) =>
 		var targetPath = Path.GetFullPath(Path.Combine(repoRoot, "source", sanitized));
 		var sourceDir = Path.GetFullPath(Path.Combine(repoRoot, "source"));
 
-		if (!targetPath.StartsWith(sourceDir))
+		if (!targetPath.StartsWith(sourceDir + Path.DirectorySeparatorChar) && targetPath != sourceDir)
 			return Results.BadRequest("Invalid path");
 
 		if (!File.Exists(targetPath))


### PR DESCRIPTION
## Security Fix

Resolves code-scanning alerts [#7](https://github.com/Azure-Samples/Legacy-Modernization-Agents/security/code-scanning/7), [#8](https://github.com/Azure-Samples/Legacy-Modernization-Agents/security/code-scanning/8), [#9](https://github.com/Azure-Samples/Legacy-Modernization-Agents/security/code-scanning/9), [#10](https://github.com/Azure-Samples/Legacy-Modernization-Agents/security/code-scanning/10) — **Uncontrolled data used in path expression** (`cs/path-injection`).

### `/api/prompts/score/{promptId}` (alerts #7, #8) — Real vulnerability
- `promptId` was used directly in `Path.Combine()` with no sanitization
- A value like `../../etc/passwd` could read arbitrary files
- **Fix:** Sanitize with `Path.GetFileName()` + directory containment check

### `/api/source/files/{fileName}` (alerts #9, #10) — Hardening
- Already had `Path.GetFileName()` sanitization + `StartsWith` check
- Strengthened `StartsWith` with `Path.DirectorySeparatorChar` suffix to prevent prefix-matching bypasses (e.g. a sibling dir named `source2`)

### Verification
- No build errors from `Program.cs`