### PR TITLE
docs: add Security entry to CHANGELOG for ProcessManager command injection fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Provider label display** — AI provider labels in the portal header now correctly reflect the active provider (was showing `AzureOpenAI` for all providers).
 - **XSS hardening** — API-supplied model names are HTML-escaped before DOM insertion in the portal setup modal.
 
+### Security
+- **Command injection fix in `ProcessManager`** — `ProcessManager.StartRun()` now uses `ProcessStartInfo.ArgumentList` instead of `ProcessStartInfo.Arguments` to pass arguments to `doctor.sh` subprocesses. This eliminates the command injection risk that existed when user-controlled values were interpolated into the `Arguments` string. Resolves [code-scanning alert #6](https://github.com/Azure-Samples/Legacy-Modernization-Agents/security/code-scanning/6).
+
 ## [3.0.0] - 2026-03-17
 
 ### Added


### PR DESCRIPTION
## Documentation Update

Closes #92

Adds a `### Security` block to `[Unreleased]` in `CHANGELOG.md` documenting PR #90 — the switch from `ProcessStartInfo.Arguments` to `ProcessStartInfo.ArgumentList` in `ProcessManager.StartRun()` that resolved [code-scanning alert #6](https://github.com/Azure-Samples/Legacy-Modernization-Agents/security/code-scanning/6).