### PR TITLE
fix: remove duplicate Dispose() stub in CopilotChatClient

### DIFF
--- a/Agents/Infrastructure/CopilotChatClient.cs
+++ b/Agents/Infrastructure/CopilotChatClient.cs
@@ -285,9 +285,6 @@ public sealed class CopilotChatClient : IChatClient, IAsyncDisposable
     /// </remarks>
     public void Dispose()
     {
-        _disposed = true;
-    public void Dispose()
-    {
         if (_disposed) return;
         _disposed = true;
         try { _client.ForceStopAsync().GetAwaiter().GetResult(); } catch { /* best-effort */ }


### PR DESCRIPTION
## Summary

- Removed a malformed duplicate `Dispose()` method body that was incorrectly nested inside the real `Dispose()` implementation in `CopilotChatClient.cs`
- This caused a `CS1513: } expected` build error, preventing the project from compiling
- The correct guarded implementation (null-checks `_disposed`, calls `ForceStopAsync()` best-effort) is preserved

## Test plan

- [ ] Run `dotnet build CobolToQuarkusMigration.csproj` — should succeed with 0 errors
- [ ] Confirm `CopilotChatClient.Dispose()` and `DisposeAsync()` both behave correctly (set `_disposed`, stop the Copilot CLI process)