### PR TITLE
Update reverse engineering docs for Use Cases output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`ChatClientFactory` `InvalidOperationException`** — `CreateFromSettings()` now throws a descriptive `InvalidOperationException` when called with an unrecognised `ServiceType`, instead of returning `null` and causing a downstream null-reference crash.
 - **Provider label display** — AI provider labels in the portal header now correctly reflect the active provider (was showing `AzureOpenAI` for all providers).
 - **XSS hardening** — API-supplied model names are HTML-escaped before DOM insertion in the portal setup modal.
+- **Business logic report — Use Cases output** — The `reverse-engineering-details.md` report now consistently uses `### Use Cases` as the section heading. Each entry now renders `Trigger:`, `Description:`, `Benefit:`, and `Key Steps:` fields, and markdown generation is centralized in `BusinessLogicMarkdownFormatter`.
 
 ### Security
 - **Command injection fix in `ProcessManager`** — `ProcessManager.StartRun()` now uses `ProcessStartInfo.ArgumentList` instead of `ProcessStartInfo.Arguments` to pass arguments to `doctor.sh` subprocesses. This eliminates the command injection risk that existed when user-controlled values were interpolated into the `Arguments` string. Resolves [code-scanning alert #6](https://github.com/Azure-Samples/Legacy-Modernization-Agents/security/code-scanning/6).

--- a/docs/REVERSE_ENGINEERING_ARCHITECTURE.md
+++ b/docs/REVERSE_ENGINEERING_ARCHITECTURE.md
@@ -86,7 +86,7 @@ graph TB
     subgraph "Data Models"
         CobolFile[CobolFile]
         CobolAnalysis[CobolAnalysis]
-        BusinessLogicModel[BusinessLogic<br/>- UseCases<br/>- Features<br/>- BusinessRules]
+        BusinessLogicModel[BusinessLogic<br/>- Use Cases<br/>- Features<br/>- BusinessRules]
     end
     
     subgraph "Chunking Infrastructure"

--- a/docs/REVERSE_ENGINEERING_ARCHITECTURE.md
+++ b/docs/REVERSE_ENGINEERING_ARCHITECTURE.md
@@ -11,7 +11,7 @@ The reverse engineering process extracts business logic from COBOL source code, 
 | Component | Model | Purpose |
 |-----------|-------|---------|
 | COBOL Analyzer | `gpt-5.1-codex-mini` | Technical structure analysis (divisions, paragraphs, data) |
-| Business Logic Extractor | `gpt-5.1-codex-mini` | Business rules, features, user stories extraction |
+| Business Logic Extractor | `gpt-5.1-codex-mini` | Business rules, features, use cases extraction |
 | Portal Chat | `gpt-5.1-chat` | Interactive Q&A about migration results |
 
 **Configuration:** `Config/appsettings.json`
@@ -86,7 +86,7 @@ graph TB
     subgraph "Data Models"
         CobolFile[CobolFile]
         CobolAnalysis[CobolAnalysis]
-        BusinessLogicModel[BusinessLogic<br/>- UserStories<br/>- Features<br/>- BusinessRules]
+        BusinessLogicModel[BusinessLogic<br/>- UseCases<br/>- Features<br/>- BusinessRules]
     end
     
     subgraph "Chunking Infrastructure"

--- a/docs/REVERSE_ENGINEERING_ARCHITECTURE.md
+++ b/docs/REVERSE_ENGINEERING_ARCHITECTURE.md
@@ -11,7 +11,7 @@ The reverse engineering process extracts business logic from COBOL source code, 
 | Component | Model | Purpose |
 |-----------|-------|---------|
 | COBOL Analyzer | `gpt-5.1-codex-mini` | Technical structure analysis (divisions, paragraphs, data) |
-| Business Logic Extractor | `gpt-5.1-codex-mini` | Business rules, features, use cases extraction |
+| Business Logic Extractor | `gpt-5.1-codex-mini` | Extraction of business rules, features, and use cases |
 | Portal Chat | `gpt-5.1-chat` | Interactive Q&A about migration results |
 
 **Configuration:** `Config/appsettings.json`


### PR DESCRIPTION
Update the unreleased changelog and reverse engineering architecture docs to reflect the current reverse-engineering report format.

Fixes #116